### PR TITLE
Allow addresses to opt into time-locking their transfers

### DIFF
--- a/src/OrigamiGovernanceToken.sol
+++ b/src/OrigamiGovernanceToken.sol
@@ -194,7 +194,7 @@ contract OrigamiGovernanceToken is
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal override whenNotPaused {
         (uint256 lockedAmount, uint256 deadline) = getTransferLock(from);
         if (deadline > 0 && balanceOf(from) >= amount && balanceOf(from) - amount < lockedAmount) {
-            require(block.timestamp > deadline, "TransferLock: address lockup has not expired");
+            require(block.timestamp > deadline, "TransferLock: this exceeds your available balance while locked");
         }
         super._beforeTokenTransfer(from, to, amount);
     }

--- a/test/OrigamiGovernanceToken.t.sol
+++ b/test/OrigamiGovernanceToken.t.sol
@@ -693,7 +693,7 @@ contract GovernanceTokenTransferLockTest is OGTHelper {
         vm.prank(mintee);
         token.setTransferLock(100, 1704585600); // 2024-01-01
         vm.prank(mintee);
-        vm.expectRevert("TransferLock: address timelock has not expired");
+        vm.expectRevert("TransferLock: this exceeds your available balance while locked");
         token.transfer(minter, 10);
     }
 
@@ -715,7 +715,7 @@ contract GovernanceTokenTransferLockTest is OGTHelper {
         // timelock date is inclusive, so an attempt to transfer at the exact timelock time will fail
         vm.warp(1704585600); // 2024-01-01
         vm.prank(mintee);
-        vm.expectRevert("TransferLock: address timelock has not expired");
+        vm.expectRevert("TransferLock: this exceeds your available balance while locked");
         token.transfer(mintee, 10);
 
         // warp to the second immediately after the timelock expires and try again


### PR DESCRIPTION
This allows an address to set a unix timestamp (UTC) that their transfers will be disabled until such time passes.