### PR TITLE
Adding ERC20Permit breaks storage layout

### DIFF
--- a/src/OrigamiGovernanceToken.sol
+++ b/src/OrigamiGovernanceToken.sol
@@ -10,6 +10,7 @@ import "@oz-upgradeable/security/PausableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@oz-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC20/extensions/ERC20CappedUpgradeable.sol";
+import "@oz-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 
 /**
  * @title Origami Governance Token
@@ -24,6 +25,7 @@ contract OrigamiGovernanceToken is
     PausableUpgradeable,
     AccessControlUpgradeable,
     ERC20CappedUpgradeable,
+    ERC20PermitUpgradeable,
     Votes
 {
     /**


### PR DESCRIPTION
It looks like it's probably related to their EIP712 implementation. You can reproduce by running:

```shell
./bin/jib/  check-storage OrigamiGovernanceToken
```

This compares the `forge inspect --pretty storage-layout` output against the last checked in version of this output. For convenience, here is the full output:

```
1,21c1,28
< | Name             | Type                                                         | Slot | Offset | Bytes | Contract                                                 |
< |------------------|--------------------------------------------------------------|------|--------|-------|----------------------------------------------------------|
< | _initialized     | uint8                                                        | 0    | 0      | 1     | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _initializing    | bool                                                         | 0    | 1      | 1     | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[50]                                                  | 1    | 0      | 1600  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _balances        | mapping(address => uint256)                                  | 51   | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _allowances      | mapping(address => mapping(address => uint256))              | 52   | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _totalSupply     | uint256                                                      | 53   | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _name            | string                                                       | 54   | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _symbol          | string                                                       | 55   | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[45]                                                  | 56   | 0      | 1440  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[50]                                                  | 101  | 0      | 1600  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _paused          | bool                                                         | 151  | 0      | 1     | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[49]                                                  | 152  | 0      | 1568  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[50]                                                  | 201  | 0      | 1600  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _roles           | mapping(bytes32 => struct AccessControlUpgradeable.RoleData) | 251  | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[49]                                                  | 252  | 0      | 1568  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _cap             | uint256                                                      | 301  | 0      | 32    | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | __gap            | uint256[50]                                                  | 302  | 0      | 1600  | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _burnEnabled     | bool                                                         | 352  | 0      | 1     | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _transferEnabled | bool                                                         | 352  | 1      | 1     | src/OldOrigamiGovernanceToken.sol:OrigamiGovernanceToken |
---
> | Name                             | Type                                                           | Slot | Offset | Bytes | Contract                                              |
> |----------------------------------|----------------------------------------------------------------|------|--------|-------|-------------------------------------------------------|
> | _initialized                     | uint8                                                          | 0    | 0      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _initializing                    | bool                                                           | 0    | 1      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[50]                                                    | 1    | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _balances                        | mapping(address => uint256)                                    | 51   | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _allowances                      | mapping(address => mapping(address => uint256))                | 52   | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _totalSupply                     | uint256                                                        | 53   | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _name                            | string                                                         | 54   | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _symbol                          | string                                                         | 55   | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[45]                                                    | 56   | 0      | 1440  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[50]                                                    | 101  | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _paused                          | bool                                                           | 151  | 0      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[49]                                                    | 152  | 0      | 1568  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[50]                                                    | 201  | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _roles                           | mapping(bytes32 => struct AccessControlUpgradeable.RoleData)   | 251  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[49]                                                    | 252  | 0      | 1568  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _cap                             | uint256                                                        | 301  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[50]                                                    | 302  | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _HASHED_NAME                     | bytes32                                                        | 352  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _HASHED_VERSION                  | bytes32                                                        | 353  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[50]                                                    | 354  | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _nonces                          | mapping(address => struct CountersUpgradeable.Counter)         | 404  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _PERMIT_TYPEHASH_DEPRECATED_SLOT | bytes32                                                        | 405  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap                            | uint256[49]                                                    | 406  | 0      | 1568  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _burnEnabled                     | bool                                                           | 455  | 0      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _transferEnabled                 | bool                                                           | 455  | 1      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | lockup                           | mapping(address => struct OrigamiGovernanceToken.TransferLock) | 456  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
```

The thing to note here is that `_HASHED_NAME` clobbers the previously existing `_burnEnabled` and `_transferEnabled` in slot 352. This would make this a breaking storage change for our previously deployed contracts.