### PR TITLE
Add EIP712Upgradeable base contract and implement

### DIFF
--- a/src/OrigamiGovernanceToken.sol
+++ b/src/OrigamiGovernanceToken.sol
@@ -10,6 +10,7 @@ import "@oz-upgradeable/security/PausableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@oz-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC20/extensions/ERC20CappedUpgradeable.sol";
+import "@oz-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 
 /**
  * @title Origami Governance Token
@@ -24,7 +25,8 @@ contract OrigamiGovernanceToken is
     PausableUpgradeable,
     AccessControlUpgradeable,
     ERC20CappedUpgradeable,
-    Votes
+    Votes,
+    EIP712Upgradeable
 {
     /**
      * @notice the role hash for granting the ability to pause the contract. By default, this role is granted to the contract admin.
@@ -100,6 +102,7 @@ contract OrigamiGovernanceToken is
         __ERC20Burnable_init();
         __ERC20Capped_init(_supplyCap);
         __ERC20_init(_name, _symbol);
+        __EIP712_init(_name, version());
         __Pausable_init();
 
         // grant all roles to the admin

--- a/src/OrigamiMembershipToken.sol
+++ b/src/OrigamiMembershipToken.sol
@@ -9,6 +9,7 @@ import "@oz-upgradeable/security/PausableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@oz-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
 import "@oz-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@oz-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import "@oz-upgradeable/utils/CountersUpgradeable.sol";
 
 /// @title Origami Membership Token
@@ -22,7 +23,8 @@ contract OrigamiMembershipToken is
     PausableUpgradeable,
     AccessControlUpgradeable,
     ERC721BurnableUpgradeable,
-    Votes
+    Votes,
+    EIP712Upgradeable
 {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
@@ -76,6 +78,7 @@ contract OrigamiMembershipToken is
         __Pausable_init();
         __AccessControl_init();
         __ERC721Burnable_init();
+        __EIP712_init(_name, version());
 
         // grant all roles to the admin
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);


### PR DESCRIPTION
Introducing the EIP712 base contract creates a storage layout conflict at slot 352. We're using the following commands to analyze the differences in the storage layout.

```shell
./bin/jib check-storage OrigamiGovernanceToken
```

~ and ~

```shell
./bin/jib check-storage OrigamiMembershipToken
```

This compares the `forge inspect --pretty storage-layout` output against the last checked in version of this output. For convenience, here is the full output for the governance token's layout differences:

```
20,22c20,25
< | _burnEnabled     | bool                                                           | 352  | 0      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | _transferEnabled | bool                                                           | 352  | 1      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
< | lockup           | mapping(address => struct OrigamiGovernanceToken.TransferLock) | 353  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
---
> | _HASHED_NAME     | bytes32                                                        | 352  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _HASHED_VERSION  | bytes32                                                        | 353  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | __gap            | uint256[50]                                                    | 354  | 0      | 1600  | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _burnEnabled     | bool                                                           | 404  | 0      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | _transferEnabled | bool                                                           | 404  | 1      | 1     | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
> | lockup           | mapping(address => struct OrigamiGovernanceToken.TransferLock) | 405  | 0      | 32    | src/OrigamiGovernanceToken.sol:OrigamiGovernanceToken |
```

...and the membership token:

```
24,27c24,30
< | _tokenIdCounter         | struct CountersUpgradeable.Counter                           | 351  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
< | tokenIdToBlockTimestamp | mapping(uint256 => uint256)                                  | 352  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
< | _metadataBaseURI        | string                                                       | 353  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
< | _transferEnabled        | bool                                                         | 354  | 0      | 1     | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
---
> | _HASHED_NAME            | bytes32                                                      | 351  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | _HASHED_VERSION         | bytes32                                                      | 352  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | __gap                   | uint256[50]                                                  | 353  | 0      | 1600  | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | _tokenIdCounter         | struct CountersUpgradeable.Counter                           | 403  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | tokenIdToBlockTimestamp | mapping(uint256 => uint256)                                  | 404  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | _metadataBaseURI        | string                                                       | 405  | 0      | 32    | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
> | _transferEnabled        | bool                                                         | 406  | 0      | 1     | src/OrigamiMembershipToken.sol:OrigamiMembershipToken |
```

The thing to note here is that slots 352 and 353 have conflicts with variables from the derived contracts with previously declared contract variables. This would make these changes breaking storage change for our previously deployed contracts.