### PR TITLE
QSP-2: addresses issue raised in QSP-2

### DIFF
--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -187,6 +187,16 @@ contract ERC20Base is
         return super.transfer(to, amount);
     }
 
+    /// @inheritdoc ERC20BurnableUpgradeable
+    function burn(uint256 amount) public override whenBurnable {
+        super.burn(amount);
+    }
+
+    /// @inheritdoc ERC20BurnableUpgradeable
+    function burnFrom(address account, uint256 amount) public override whenBurnable {
+        super.burnFrom(account, amount);
+    }
+
     /**
      * @notice Query if a contract implements an interface
      * @param interfaceId The interface identifier, as specified in ERC-165

--- a/test/token/governance/ERC20Base.t.sol
+++ b/test/token/governance/ERC20Base.t.sol
@@ -199,11 +199,22 @@ contract BurnGovernanceTokenTest is ERC20BaseHelper {
     }
 
     function testCannotBurnAsNonHolder() public {
+        token.enableBurn();
         vm.stopPrank();
         vm.startPrank(minter);
         token.mint(mintee, 100);
         vm.expectRevert("ERC20: insufficient allowance");
         token.burnFrom(mintee, 10);
+    }
+
+    function testCannotBurnAsHolderWhenBurnIsDisabled() public {
+        vm.stopPrank();
+        vm.prank(minter);
+        token.mint(mintee, 100);
+        assertEq(token.balanceOf(mintee), 100);
+        vm.prank(mintee);
+        vm.expectRevert("Burnable: burning is disabled");
+        token.burn(100);
     }
 
     function testCanBurnAsHolderWhenBurnIsEnabled(uint96 amount) public {


### PR DESCRIPTION
This overrides the inherited functions from BurnableUpgradeable so that we can apply our `whenBurnable` modifier.