### PR TITLE
desi/eng 1152 qsp 12 missing input validation

### DIFF
--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -60,7 +60,7 @@ contract ERC20Base is
         initializer
     {
         require(admin != address(0), "Admin address cannot be zero");
-        
+
         bool tokenNameEmpty = keccak256(abi.encode(tokenName)) == keccak256(abi.encode(""));
         bool tokenSymbolEmpty = keccak256(abi.encode(tokenSymbol)) == keccak256(abi.encode(""));
         require(!(tokenNameEmpty && tokenSymbolEmpty), "ERC20Base: Token name cannot be empty");

--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -63,7 +63,8 @@ contract ERC20Base is
 
         bool tokenNameEmpty = keccak256(abi.encode(tokenName)) == keccak256(abi.encode(""));
         bool tokenSymbolEmpty = keccak256(abi.encode(tokenSymbol)) == keccak256(abi.encode(""));
-        require(!(tokenNameEmpty && tokenSymbolEmpty), "ERC20Base: Token name cannot be empty");
+        require(!tokenNameEmpty, "ERC20Base: Token name cannot be empty");
+        require(!tokenSymbolEmpty, "ERC20Base: Token symbol cannot be empty");
         __AccessControl_init();
         __ERC20Burnable_init();
         __ERC20Capped_init(supplyCap);

--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -60,7 +60,10 @@ contract ERC20Base is
         initializer
     {
         require(admin != address(0), "Admin address cannot be zero");
-
+        
+        bool tokenNameEmpty = keccak256(abi.encode(tokenName)) == keccak256(abi.encode(""));
+        bool tokenSymbolEmpty = keccak256(abi.encode(tokenSymbol)) == keccak256(abi.encode(""));
+        require(!(tokenNameEmpty && tokenSymbolEmpty), "ERC20Base: Token name cannot be empty");
         __AccessControl_init();
         __ERC20Burnable_init();
         __ERC20Capped_init(supplyCap);

--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -61,10 +61,10 @@ contract ERC20Base is
     {
         require(admin != address(0), "Admin address cannot be zero");
 
-        bool tokenNameEmpty = keccak256(abi.encode(tokenName)) == keccak256(abi.encode(""));
-        bool tokenSymbolEmpty = keccak256(abi.encode(tokenSymbol)) == keccak256(abi.encode(""));
-        require(!tokenNameEmpty, "ERC20Base: Token name cannot be empty");
-        require(!tokenSymbolEmpty, "ERC20Base: Token symbol cannot be empty");
+        bytes32 blank = keccak256(abi.encode(""));
+        require(keccak256(abi.encode(tokenName)) != blank, "ERC20Base: Token name cannot be empty");
+        require(keccak256(abi.encode(tokenSymbol)) != blank, "ERC20Base: Token symbol cannot be empty");
+
         __AccessControl_init();
         __ERC20Burnable_init();
         __ERC20Capped_init(supplyCap);

--- a/src/utils/L2StandardERC20.sol
+++ b/src/utils/L2StandardERC20.sol
@@ -61,9 +61,9 @@ contract L2StandardERC20 is ERC20Base, IL2StandardERC20 {
      */
     function setL2Bridge(address newL2Bridge) public onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldL2Bridge = l2BridgeInfoStorage().l2Bridge;
-        require(newL2Bridge != oldL2Bridge, "L2StandardERC20: L2 bridge cannot be set to same L2 bridge");        
+        require(newL2Bridge != oldL2Bridge, "L2StandardERC20: L2 bridge cannot be set to same L2 bridge");
         require(newL2Bridge != address(0), "L2StandardERC20: L2 bridge cannot be zero address");
-        
+
         l2BridgeInfoStorage().l2Bridge = newL2Bridge;
         emit L2BridgeUpdated(oldL2Bridge, newL2Bridge);
     }

--- a/src/utils/L2StandardERC20.sol
+++ b/src/utils/L2StandardERC20.sol
@@ -48,7 +48,7 @@ contract L2StandardERC20 is ERC20Base, IL2StandardERC20 {
      */
     function setL1Token(address newL1Token) public onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldL1Token = l2BridgeInfoStorage().l1Token;
-        require(newL1Token != oldL1Token, "L2StandardERC20: L1 token cannot be set to same L1 token");
+        require(newL1Token != oldL1Token, "L2StandardERC20: L1 token value must change");
         require(newL1Token != address(0), "L2StandardERC20: L1 token cannot be zero address");
 
         l2BridgeInfoStorage().l1Token = newL1Token;
@@ -61,7 +61,8 @@ contract L2StandardERC20 is ERC20Base, IL2StandardERC20 {
      */
     function setL2Bridge(address newL2Bridge) public onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldL2Bridge = l2BridgeInfoStorage().l2Bridge;
-        require(newL2Bridge != oldL2Bridge, "L2StandardERC20: L2 bridge cannot be set to same L2 bridge");
+
+        require(newL2Bridge != oldL2Bridge, "L2StandardERC20: L2 bridge value must change");
         require(newL2Bridge != address(0), "L2StandardERC20: L2 bridge cannot be zero address");
 
         l2BridgeInfoStorage().l2Bridge = newL2Bridge;

--- a/src/utils/L2StandardERC20.sol
+++ b/src/utils/L2StandardERC20.sol
@@ -48,6 +48,9 @@ contract L2StandardERC20 is ERC20Base, IL2StandardERC20 {
      */
     function setL1Token(address newL1Token) public onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldL1Token = l2BridgeInfoStorage().l1Token;
+        require(newL1Token != oldL1Token, "L2StandardERC20: L1 token cannot be set to same L1 token");
+        require(newL1Token != address(0), "L2StandardERC20: L1 token cannot be zero address");
+
         l2BridgeInfoStorage().l1Token = newL1Token;
         emit L1TokenUpdated(oldL1Token, newL1Token);
     }
@@ -58,6 +61,9 @@ contract L2StandardERC20 is ERC20Base, IL2StandardERC20 {
      */
     function setL2Bridge(address newL2Bridge) public onlyRole(DEFAULT_ADMIN_ROLE) {
         address oldL2Bridge = l2BridgeInfoStorage().l2Bridge;
+        require(newL2Bridge != oldL2Bridge, "L2StandardERC20: L2 bridge cannot be set to same L2 bridge");        
+        require(newL2Bridge != address(0), "L2StandardERC20: L2 bridge cannot be zero address");
+        
         l2BridgeInfoStorage().l2Bridge = newL2Bridge;
         emit L2BridgeUpdated(oldL2Bridge, newL2Bridge);
     }

--- a/src/utils/TransferLocks.sol
+++ b/src/utils/TransferLocks.sol
@@ -18,42 +18,64 @@ import "@diamond/interfaces/IERC165.sol";
  */
 contract TransferLocks is ERC20Base, IERC165, ITransferLocks {
     /// @inheritdoc ITransferLocks
-    function addTransferLock(uint256 amount, uint256 deadline) public whenValidLock(amount, deadline) {
+    function addTransferLock(
+        uint256 amount,
+        uint256 deadline
+    ) public whenValidLock(amount, deadline) {
         TransferLocksStorage.addTransferLock(msg.sender, amount, deadline);
     }
 
     /// @inheritdoc ITransferLocks
-    function getTransferLockTotal(address account) public view returns (uint256 amount) {
+    function getTransferLockTotal(
+        address account
+    ) public view returns (uint256 amount) {
         return TransferLocksStorage.getTotalLockedAt(account, block.timestamp);
     }
 
     /// @inheritdoc ITransferLocks
-    function getTransferLockTotalAt(address account, uint256 timestamp) public view returns (uint256 amount) {
+    function getTransferLockTotalAt(
+        address account,
+        uint256 timestamp
+    ) public view returns (uint256 amount) {
         return TransferLocksStorage.getTotalLockedAt(account, timestamp);
     }
 
     /// @inheritdoc ITransferLocks
-    function getAvailableBalanceAt(address account, uint256 timestamp) public view returns (uint256 amount) {
-        uint256 totalLocked = TransferLocksStorage.getTotalLockedAt(account, timestamp);
+    function getAvailableBalanceAt(
+        address account,
+        uint256 timestamp
+    ) public view returns (uint256 amount) {
+        uint256 totalLocked = TransferLocksStorage.getTotalLockedAt(
+            account,
+            timestamp
+        );
         return balanceOf(account) - totalLocked;
     }
 
     /// @dev Override ERC20Upgradeable._beforeTokenTransfer to check for transfer locks.
-    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual override {
         uint256 lockedAmount = getTransferLockTotalAt(from, block.timestamp);
         // slither-disable-next-line timestamp
         if (lockedAmount > 0 && balanceOf(from) >= amount) {
             // slither-disable-next-line timestamp
-            require(balanceOf(from) - amount >= lockedAmount, "TransferLock: this exceeds your unlocked balance");
+            require(
+                balanceOf(from) - amount >= lockedAmount,
+                "TransferLock: this exceeds your unlocked balance"
+            );
         }
         super._beforeTokenTransfer(from, to, amount);
     }
 
     /// @inheritdoc ITransferLocks
-    function transferWithLock(address recipient, uint256 amount, uint256 deadline)
-        public
-        whenValidLock(amount, deadline)
-    {
+    function transferWithLock(
+        address recipient,
+        uint256 amount,
+        uint256 deadline
+    ) public whenValidLock(amount, deadline) {
         _transfer(msg.sender, recipient, amount);
         TransferLocksStorage.addTransferLock(recipient, amount, deadline);
     }
@@ -64,23 +86,36 @@ contract TransferLocks is ERC20Base, IERC165, ITransferLocks {
         uint256[] calldata amounts,
         uint256[] calldata deadlines
     ) external {
-        require(recipients.length == amounts.length, "TransferLock: recipients and amounts must be the same length");
-        require(recipients.length == deadlines.length, "TransferLock: recipients and deadlines must be the same length");
+        require(
+            recipients.length == amounts.length,
+            "TransferLock: recipients and amounts must be the same length"
+        );
+        require(
+            recipients.length == deadlines.length,
+            "TransferLock: recipients and deadlines must be the same length"
+        );
         for (uint256 i = 0; i < recipients.length; i++) {
             transferWithLock(recipients[i], amounts[i], deadlines[i]);
         }
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC20Base, IERC165) returns (bool) {
-        return interfaceId == type(ITransferLocks).interfaceId || super.supportsInterface(interfaceId);
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC20Base, IERC165) returns (bool) {
+        return
+            interfaceId == type(ITransferLocks).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @dev Modifier to check that the deadline is in the future and the amount is not greater than the available balance.
     modifier whenValidLock(uint256 amount, uint256 deadline) {
         // slither-disable-next-line timestamp
         require(amount > 0, "TransferLock: amount must be greater than zero");
-        require(deadline > block.timestamp, "TransferLock: deadline must be in the future");
+        require(
+            deadline > block.timestamp,
+            "TransferLock: deadline must be in the future"
+        );
         require(
             amount <= getAvailableBalanceAt(msg.sender, block.timestamp),
             "TransferLock: amount cannot exceed available balance"

--- a/src/utils/Votes.sol
+++ b/src/utils/Votes.sol
@@ -102,6 +102,7 @@ abstract contract Votes is IVotes, IVotesToken {
      * @param delegatee the address to delegate voting units to
      */
     function handleDelegation(address delegator, address delegatee) internal {
+        require(delegatee != address(0), "Votes: delegatee cannot be zero address");
         address oldDelegate = Checkpoints.delegates(delegator);
         Checkpoints.delegate(delegator, delegatee);
         Checkpoints.moveDelegation(oldDelegate, delegatee, IVotesToken(this).balanceOf(delegator));

--- a/test/OrigamiGovernanceToken.t.sol
+++ b/test/OrigamiGovernanceToken.t.sol
@@ -27,21 +27,14 @@ abstract contract OGTHelper is OGTAddressHelper, Test {
         vm.startPrank(deployer);
         impl = new OrigamiGovernanceToken();
         proxyAdmin = new ProxyAdmin();
-        token = deployNewToken(
-            owner,
-            "Deciduous Tree DAO Governance",
-            "DTDG",
-            10000000000000000000000000000
-        );
+        token = deployNewToken(owner, "Deciduous Tree DAO Governance", "DTDG", 10000000000000000000000000000);
         vm.stopPrank();
     }
 
-    function deployNewToken(
-        address _owner,
-        string memory _name,
-        string memory _symbol,
-        uint256 _cap
-    ) public returns (OrigamiGovernanceToken _token) {
+    function deployNewToken(address _owner, string memory _name, string memory _symbol, uint256 _cap)
+        public
+        returns (OrigamiGovernanceToken _token)
+    {
         TransparentUpgradeableProxy proxy;
         proxy = new TransparentUpgradeableProxy(
             address(impl),
@@ -71,12 +64,7 @@ contract DeployGovernanceTokenTest is OGTAddressHelper, Test {
 
     function testDeploy() public {
         token = OrigamiGovernanceToken(address(proxy));
-        token.initialize(
-            owner,
-            "Deciduous Tree DAO Governance",
-            "DTDG",
-            10000000000000000000000000000
-        );
+        token.initialize(owner, "Deciduous Tree DAO Governance", "DTDG", 10000000000000000000000000000);
         assertEq(token.name(), "Deciduous Tree DAO Governance");
         assertEq(token.symbol(), "DTDG");
         assertEq(token.totalSupply(), 0);
@@ -86,12 +74,7 @@ contract DeployGovernanceTokenTest is OGTAddressHelper, Test {
     function testDeployRevertsWhenAdminIsAdressZero() public {
         token = OrigamiGovernanceToken(address(proxy));
         vm.expectRevert("Admin address cannot be zero");
-        token.initialize(
-            address(0),
-            "Deciduous Tree DAO Governance",
-            "DTDG",
-            10000000000000000000000000000
-        );
+        token.initialize(address(0), "Deciduous Tree DAO Governance", "DTDG", 10000000000000000000000000000);
     }
 }
 
@@ -115,12 +98,7 @@ contract UpgradeGovernanceTokenTest is Test, OGTAddressHelper {
         );
         tokenV1 = OrigamiGovernanceToken(address(proxy));
 
-        tokenV1.initialize(
-            owner,
-            "Deciduous Tree DAO Governance",
-            "DTDG",
-            10000000000000000000000000000
-        );
+        tokenV1.initialize(owner, "Deciduous Tree DAO Governance", "DTDG", 10000000000000000000000000000);
     }
 
     function testCanInitialize() public {
@@ -129,12 +107,7 @@ contract UpgradeGovernanceTokenTest is Test, OGTAddressHelper {
 
     function testCannotInitializeTwice() public {
         vm.expectRevert("Initializable: contract is already initialized");
-        tokenV1.initialize(
-            owner,
-            "EVEN MOAR Deciduous Tree DAO Governance",
-            "EMDTDG",
-            10000000000000000000000000000
-        );
+        tokenV1.initialize(owner, "EVEN MOAR Deciduous Tree DAO Governance", "EMDTDG", 10000000000000000000000000000);
     }
 
     function testCanUpgrade() public {
@@ -153,16 +126,8 @@ contract UpgradeGovernanceTokenTest is Test, OGTAddressHelper {
 }
 
 contract GovernanceTokenVotingPowerTest is OGTHelper {
-    event DelegateChanged(
-        address indexed delegator,
-        address indexed fromDelegate,
-        address indexed toDelegate
-    );
-    event DelegateVotesChanged(
-        address indexed delegate,
-        uint256 previousBalance,
-        uint256 newBalance
-    );
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+    event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance);
 
     function setUp() public {
         vm.startPrank(owner);

--- a/test/OrigamiMembershipToken.t.sol
+++ b/test/OrigamiMembershipToken.t.sol
@@ -378,7 +378,7 @@ contract TransferrabilityMembershipTokenTest is OMTHelper {
         emit TransferEnabled(owner, true);
         token.enableTransfer();
     }
-
+ 
     function testEmitsTransferDisabledEvent() public {
         token.enableTransfer();
         vm.expectEmit(true, true, true, true, address(token));
@@ -414,6 +414,15 @@ contract TransferrabilityMembershipTokenTest is OMTHelper {
         vm.prank(mintee);
         token.safeTransferFrom(mintee, recipient, 1);
         assertEq(token.balanceOf(recipient), 1);
+    }
+
+    function testCannotTransferZeroMembershipTokens() public {
+        token.safeMint(mintee);
+        token.enableTransfer();
+        vm.stopPrank();
+        vm.prank(mintee);
+        vm.expectRevert(bytes("ERC721: invalid token ID"));
+        token.safeTransferFrom(mintee, recipient, 0);
     }
 
     function testOnlyOwnerCanTransferWhenEnabled() public {

--- a/test/OrigamiMembershipToken.t.sol
+++ b/test/OrigamiMembershipToken.t.sol
@@ -378,7 +378,7 @@ contract TransferrabilityMembershipTokenTest is OMTHelper {
         emit TransferEnabled(owner, true);
         token.enableTransfer();
     }
- 
+
     function testEmitsTransferDisabledEvent() public {
         token.enableTransfer();
         vm.expectEmit(true, true, true, true, address(token));

--- a/test/token/governance/ERC20Base.t.sol
+++ b/test/token/governance/ERC20Base.t.sol
@@ -35,7 +35,10 @@ contract ERC20BaseInitializationTest is ERC20AddressHelper, Test {
         );
         token = ERC20Base(address(proxy));
         vm.expectRevert("ERC20Base: Token name cannot be empty");
-        token.initialize(owner, "", "", 10000000000000000000000000000);
+        token.initialize(owner, "", "sym", 10000000000000000000000000000);
+
+        vm.expectRevert("ERC20Base: Token symbol cannot be empty");
+        token.initialize(owner, "name", "", 10000000000000000000000000000);
 
         vm.expectRevert("ERC20Capped: cap is 0");
         token.initialize(owner, "thing", "THI", 0);

--- a/test/token/governance/ERC20Base.t.sol
+++ b/test/token/governance/ERC20Base.t.sol
@@ -36,7 +36,7 @@ contract ERC20BaseInitializationTest is ERC20AddressHelper, Test {
         token = ERC20Base(address(proxy));
         vm.expectRevert("ERC20Base: Token name cannot be empty");
         token.initialize(owner, "", "", 10000000000000000000000000000);
-    
+
         vm.expectRevert("ERC20Capped: cap is 0");
         token.initialize(owner, "thing", "THI", 0);
     }
@@ -51,21 +51,14 @@ abstract contract ERC20BaseHelper is ERC20AddressHelper, Test {
         vm.startPrank(deployer);
         impl = new ERC20Base();
         proxyAdmin = new ProxyAdmin();
-        token = deployNewToken(
-            owner,
-            "Deciduous Tree DAO Governance",
-            "DTDG",
-            10000000000000000000000000000
-        );
+        token = deployNewToken(owner, "Deciduous Tree DAO Governance", "DTDG", 10000000000000000000000000000);
         vm.stopPrank();
     }
 
-    function deployNewToken(
-        address _owner,
-        string memory _name,
-        string memory _symbol,
-        uint256 _cap
-    ) public returns (ERC20Base _token) {
+    function deployNewToken(address _owner, string memory _name, string memory _symbol, uint256 _cap)
+        public
+        returns (ERC20Base _token)
+    {
         TransparentUpgradeableProxy proxy;
         proxy = new TransparentUpgradeableProxy(
             address(impl),
@@ -176,9 +169,7 @@ contract BurnGovernanceTokenTest is ERC20BaseHelper {
         assertFalse(token.burnable());
     }
 
-    function testRevertsWhenNonAdminAttemptsToEnableBurn(
-        address nonAdmin
-    ) public {
+    function testRevertsWhenNonAdminAttemptsToEnableBurn(address nonAdmin) public {
         vm.assume(nonAdmin != owner);
         vm.assume(nonAdmin != address(proxyAdmin));
         vm.stopPrank();
@@ -193,9 +184,7 @@ contract BurnGovernanceTokenTest is ERC20BaseHelper {
         token.enableBurn();
     }
 
-    function testRevertsWhenNonAdminAttemptsToDisableBurn(
-        address nonAdmin
-    ) public {
+    function testRevertsWhenNonAdminAttemptsToDisableBurn(address nonAdmin) public {
         vm.assume(nonAdmin != owner);
         vm.assume(nonAdmin != address(proxyAdmin));
         vm.stopPrank();
@@ -216,9 +205,7 @@ contract BurnGovernanceTokenTest is ERC20BaseHelper {
         token.enableBurn();
     }
 
-    function testRevertsWhenCallingDisableBurnAndBurnIsAlreadyDisabled()
-        public
-    {
+    function testRevertsWhenCallingDisableBurnAndBurnIsAlreadyDisabled() public {
         vm.expectRevert("Burnable: burning is disabled");
         token.disableBurn();
     }
@@ -266,9 +253,7 @@ contract BurnGovernanceTokenTest is ERC20BaseHelper {
         assertEq(token.balanceOf(mintee), 0);
     }
 
-    function testCanBurnFromWalletWithAllowanceWhenEnabled(
-        uint96 amount
-    ) public {
+    function testCanBurnFromWalletWithAllowanceWhenEnabled(uint96 amount) public {
         vm.assume(amount < token.cap());
         token.enableBurn();
         vm.stopPrank();
@@ -405,9 +390,7 @@ contract PauseGovernanceTokenTest is ERC20BaseHelper {
         assertEq(token.balanceOf(minter), amount);
     }
 
-    function testCannotTransferWhenPausedAndTransferEnabled(
-        uint96 amount
-    ) public {
+    function testCannotTransferWhenPausedAndTransferEnabled(uint96 amount) public {
         vm.assume(amount < token.cap());
         token.mint(mintee, amount);
         token.enableTransfer();

--- a/test/utils/L2StandardERC20.t.sol
+++ b/test/utils/L2StandardERC20.t.sol
@@ -58,19 +58,33 @@ contract TestL2ChildContract is L2ChildContractHelper {
     }
 
     function testSetL1Token() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         vm.expectEmit(true, true, true, true, address(child));
         emit L1TokenUpdated(address(0x3), address(0x5));
         child.setL1Token(address(0x5));
         assertEq(child.l1Token(), address(0x5));
+
+        vm.expectRevert("L2StandardERC20: L1 token cannot be set to same L1 token");
+        child.setL1Token(address(0x5));
+
+        vm.expectRevert("L2StandardERC20: L1 token cannot be zero address");
+        child.setL1Token(address(0x0));
+        vm.stopPrank();
     }
 
     function testSetL2Bridge() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         vm.expectEmit(true, true, true, true, address(child));
         emit L2BridgeUpdated(address(0x4), address(0x6));
         child.setL2Bridge(address(0x6));
         assertEq(child.l2Bridge(), address(0x6));
+        
+        vm.expectRevert("L2StandardERC20: L2 bridge cannot be set to same L2 bridge");
+        child.setL2Bridge(address(0x6));
+
+        vm.expectRevert("L2StandardERC20: L2 bridge cannot be zero address");
+        child.setL2Bridge(address(0x0));
+        vm.stopPrank();
     }
 
     function testMint() public {

--- a/test/utils/L2StandardERC20.t.sol
+++ b/test/utils/L2StandardERC20.t.sol
@@ -64,7 +64,7 @@ contract TestL2ChildContract is L2ChildContractHelper {
         child.setL1Token(address(0x5));
         assertEq(child.l1Token(), address(0x5));
 
-        vm.expectRevert("L2StandardERC20: L1 token cannot be set to same L1 token");
+        vm.expectRevert("L2StandardERC20: L1 token value must change");
         child.setL1Token(address(0x5));
 
         vm.expectRevert("L2StandardERC20: L1 token cannot be zero address");
@@ -79,7 +79,7 @@ contract TestL2ChildContract is L2ChildContractHelper {
         child.setL2Bridge(address(0x6));
         assertEq(child.l2Bridge(), address(0x6));
 
-        vm.expectRevert("L2StandardERC20: L2 bridge cannot be set to same L2 bridge");
+        vm.expectRevert("L2StandardERC20: L2 bridge value must change");
         child.setL2Bridge(address(0x6));
 
         vm.expectRevert("L2StandardERC20: L2 bridge cannot be zero address");

--- a/test/utils/L2StandardERC20.t.sol
+++ b/test/utils/L2StandardERC20.t.sol
@@ -78,7 +78,7 @@ contract TestL2ChildContract is L2ChildContractHelper {
         emit L2BridgeUpdated(address(0x4), address(0x6));
         child.setL2Bridge(address(0x6));
         assertEq(child.l2Bridge(), address(0x6));
-        
+
         vm.expectRevert("L2StandardERC20: L2 bridge cannot be set to same L2 bridge");
         child.setL2Bridge(address(0x6));
 

--- a/test/utils/Votes.t.sol
+++ b/test/utils/Votes.t.sol
@@ -72,6 +72,13 @@ contract BaselineTest is VotesTestHelper {
         assertEq(votes.getPastVotes(recipient, 42), 100);
     }
 
+    function testDelegateDelegateeCannotBeZeroAddress() public {
+        vm.startPrank(recipient);
+        vm.expectRevert("Votes: delegatee cannot be zero address");
+        votes.delegate(address(0));
+        vm.stopPrank();
+    }
+
     function testDelegateBySig() public {
         bytes32 accountOneR = 0x30c6da6c49bf7e3231438b6b2ca58532998303d4d764e9268c0a28814405d0c2;
         bytes32 accountOneS = 0x19f31dd0a9b12cdd840ff3a26aa78d9d281a99dff9470bc73da84d301868ba0a;

--- a/test/utils/Votes.t.sol
+++ b/test/utils/Votes.t.sol
@@ -72,7 +72,7 @@ contract BaselineTest is VotesTestHelper {
         assertEq(votes.getPastVotes(recipient, 42), 100);
     }
 
-    function testDelegateDelegateeCannotBeZeroAddress() public {
+    function testCannotDelegateToZeroAddress() public {
         vm.startPrank(recipient);
         vm.expectRevert("Votes: delegatee cannot be zero address");
         votes.delegate(address(0));


### PR DESCRIPTION
QSP-12 Step1 - Validate inputs on Initialize for ERC20Base
QSP-12 Step2
     - Add validation to L2StandardERC20 (setL1Token)
     - Add validation to L2StandardERC20 (setL2Bridge)
QSP-12 Step3 - Add validation to addTransferLock
QSP-12 Step5 - Added validation to internal function handleDelegation such that it covers both delegate and delegateBySig