### PR TITLE
Governor: enableProposalToken

### DIFF
--- a/src/governor/GovernorSettingsFacet.sol
+++ b/src/governor/GovernorSettingsFacet.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/IGovernorSettings.sol";
-import "src/utils/GovernorStorage.sol";
+import {IGovernorSettings} from "src/interfaces/IGovernorSettings.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @title Origami Governor Settings Facet
@@ -164,6 +164,16 @@ contract GovernorSettingsFacet is IGovernorSettings {
     function setVotingPeriod(uint64 newVotingPeriod) public onlyGovernance {
         GovernorStorage.setVotingPeriod(newVotingPeriod);
     }
+
+    /**
+     * @notice update proposal token validity.
+     * @param proposalToken the proposal token address.
+     * @param valid whether the proposal token is valid.
+     * emits ProposalTokenValidSet event.
+     */
+     function enableProposalToken(address proposalToken, bool valid) public onlyGovernance {
+        GovernorStorage.enableProposalToken(proposalToken, valid);
+     }
 
     /**
      * @dev returns the GovernorConfig storage pointer.

--- a/src/governor/lib/TokenWeightStrategy.sol
+++ b/src/governor/lib/TokenWeightStrategy.sol
@@ -21,8 +21,6 @@ library TokenWeightStrategy {
      * @return the weight with the weighting strategy applied to it.
      */
     function applyStrategy(uint256 weight, bytes4 weightingSelector) internal pure returns (uint256) {
-        // We check for success and only issue this as staticcall
-
         if (weightingSelector == simpleWeightSelector) {
             return simpleWeight(weight);
         } else if (weightingSelector == quadraticWeightSelector) {

--- a/src/utils/DiamondDeployHelper.sol
+++ b/src/utils/DiamondDeployHelper.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/governor/GovernorCoreFacet.sol";
-import "src/governor/GovernorSettingsFacet.sol";
-import "src/governor/GovernorTimelockControlFacet.sol";
+import {GovernorCoreFacet} from "src/governor/GovernorCoreFacet.sol";
+import {GovernorSettingsFacet} from "src/governor/GovernorSettingsFacet.sol";
+import {GovernorTimelockControlFacet} from "src/governor/GovernorTimelockControlFacet.sol";
 
-import "@diamond/facets/DiamondCutFacet.sol";
-import "@diamond/facets/DiamondLoupeFacet.sol";
-import "@diamond/facets/OwnershipFacet.sol";
+import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "@diamond/facets/OwnershipFacet.sol";
+import {IDiamondCut} from "@diamond/interfaces/IDiamondCut.sol";
 
 /**
  * @author Origami
@@ -53,7 +54,7 @@ library DiamondDeployHelper {
         pure
         returns (IDiamondCut.FacetCut memory governorCoreCut)
     {
-        bytes4[] memory selectors = new bytes4[](32);
+        bytes4[] memory selectors = new bytes4[](34);
         selectors[0] = facet.CANCELLER_ROLE.selector;
         selectors[1] = facet.DEFAULT_ADMIN_ROLE.selector;
         selectors[2] = facet.EIP712_TYPEHASH.selector;
@@ -64,28 +65,30 @@ library DiamondDeployHelper {
         selectors[7] = facet.castVoteWithReason.selector;
         selectors[8] = facet.castVoteWithReasonBySig.selector;
         selectors[9] = facet.domainSeparatorV4.selector;
-        selectors[10] = facet.getRoleAdmin.selector;
-        selectors[11] = facet.getVotes.selector;
-        selectors[12] = facet.grantRole.selector;
-        selectors[13] = facet.hasRole.selector;
-        selectors[14] = facet.hasVoted.selector;
-        selectors[15] = facet.hashProposal.selector;
-        selectors[16] = facet.name.selector;
-        selectors[17] = facet.proposalDeadline.selector;
-        selectors[18] = facet.proposalSnapshot.selector;
-        selectors[19] = facet.proposalVotes.selector;
-        selectors[20] = facet.propose.selector;
-        selectors[21] = facet.proposeBySig.selector;
-        selectors[22] = facet.proposeWithParams.selector;
-        selectors[23] = facet.proposeWithParamsBySig.selector;
-        selectors[24] = facet.proposeWithTokenAndCountingStrategy.selector;
-        selectors[25] = facet.proposeWithTokenAndCountingStrategyBySig.selector;
-        selectors[26] = facet.quorum.selector;
-        selectors[27] = facet.renounceRole.selector;
-        selectors[28] = facet.revokeRole.selector;
-        selectors[29] = facet.simpleWeight.selector;
-        selectors[30] = facet.state.selector;
-        selectors[31] = facet.version.selector;
+        selectors[10] = facet.getAccountNonce.selector;
+        selectors[11] = facet.getRoleAdmin.selector;
+        selectors[12] = facet.getVotes.selector;
+        selectors[13] = facet.grantRole.selector;
+        selectors[14] = facet.hasRole.selector;
+        selectors[15] = facet.hasVoted.selector;
+        selectors[16] = facet.hashProposal.selector;
+        selectors[17] = facet.isProposalTokenEnabled.selector;
+        selectors[18] = facet.name.selector;
+        selectors[19] = facet.proposalDeadline.selector;
+        selectors[20] = facet.proposalSnapshot.selector;
+        selectors[21] = facet.proposalVotes.selector;
+        selectors[22] = facet.propose.selector;
+        selectors[23] = facet.proposeBySig.selector;
+        selectors[24] = facet.proposeWithParams.selector;
+        selectors[25] = facet.proposeWithParamsBySig.selector;
+        selectors[26] = facet.proposeWithTokenAndCountingStrategy.selector;
+        selectors[27] = facet.proposeWithTokenAndCountingStrategyBySig.selector;
+        selectors[28] = facet.quorum.selector;
+        selectors[29] = facet.renounceRole.selector;
+        selectors[30] = facet.revokeRole.selector;
+        selectors[31] = facet.simpleWeight.selector;
+        selectors[32] = facet.state.selector;
+        selectors[33] = facet.version.selector;
 
         governorCoreCut = IDiamondCut.FacetCut({
             facetAddress: address(facet),
@@ -99,25 +102,26 @@ library DiamondDeployHelper {
         pure
         returns (IDiamondCut.FacetCut memory governorSettingsCut)
     {
-        bytes4[] memory selectors = new bytes4[](18);
+        bytes4[] memory selectors = new bytes4[](19);
         selectors[0] = facet.defaultCountingStrategy.selector;
         selectors[1] = facet.defaultProposalToken.selector;
-        selectors[2] = facet.governanceToken.selector;
-        selectors[3] = facet.membershipToken.selector;
-        selectors[4] = facet.proposalThreshold.selector;
-        selectors[5] = facet.proposalThresholdToken.selector;
-        selectors[6] = facet.quorumNumerator.selector;
-        selectors[7] = facet.setDefaultCountingStrategy.selector;
-        selectors[8] = facet.setDefaultProposalToken.selector;
-        selectors[9] = facet.setGovernanceToken.selector;
-        selectors[10] = facet.setMembershipToken.selector;
-        selectors[11] = facet.setProposalThreshold.selector;
-        selectors[12] = facet.setProposalThresholdToken.selector;
-        selectors[13] = facet.setQuorumNumerator.selector;
-        selectors[14] = facet.setVotingDelay.selector;
-        selectors[15] = facet.setVotingPeriod.selector;
-        selectors[16] = facet.votingDelay.selector;
-        selectors[17] = facet.votingPeriod.selector;
+        selectors[2] = facet.enableProposalToken.selector;
+        selectors[3] = facet.governanceToken.selector;
+        selectors[4] = facet.membershipToken.selector;
+        selectors[5] = facet.proposalThreshold.selector;
+        selectors[6] = facet.proposalThresholdToken.selector;
+        selectors[7] = facet.quorumNumerator.selector;
+        selectors[8] = facet.setDefaultCountingStrategy.selector;
+        selectors[9] = facet.setDefaultProposalToken.selector;
+        selectors[10] = facet.setGovernanceToken.selector;
+        selectors[11] = facet.setMembershipToken.selector;
+        selectors[12] = facet.setProposalThreshold.selector;
+        selectors[13] = facet.setProposalThresholdToken.selector;
+        selectors[14] = facet.setQuorumNumerator.selector;
+        selectors[15] = facet.setVotingDelay.selector;
+        selectors[16] = facet.setVotingPeriod.selector;
+        selectors[17] = facet.votingDelay.selector;
+        selectors[18] = facet.votingPeriod.selector;
 
         governorSettingsCut = IDiamondCut.FacetCut({
             facetAddress: address(facet),

--- a/src/utils/GovernorDiamondInit.sol
+++ b/src/utils/GovernorDiamondInit.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/IAccessControl.sol";
-import "src/interfaces/IGovernor.sol";
-import "src/interfaces/IGovernorQuorum.sol";
-import "src/interfaces/IGovernorSettings.sol";
-import "src/interfaces/IGovernorTimelockControl.sol";
-import "src/utils/AccessControlStorage.sol";
-import "src/utils/GovernorStorage.sol";
+import {IAccessControl} from "src/interfaces/IAccessControl.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
+import {IGovernorQuorum} from "src/interfaces/IGovernorQuorum.sol";
+import {IGovernorSettings} from "src/interfaces/IGovernorSettings.sol";
+import {IGovernorTimelockControl} from "src/interfaces/IGovernorTimelockControl.sol";
+import {AccessControlStorage} from "src/utils/AccessControlStorage.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
-import "@diamond/libraries/LibDiamond.sol";
-import "@diamond/interfaces/IDiamondLoupe.sol";
-import "@diamond/interfaces/IDiamondCut.sol";
-import "@diamond/interfaces/IERC173.sol";
-import "@diamond/interfaces/IERC165.sol";
+import {LibDiamond} from "@diamond/libraries/LibDiamond.sol";
+import {IDiamondLoupe} from "@diamond/interfaces/IDiamondLoupe.sol";
+import {IDiamondCut} from "@diamond/interfaces/IDiamondCut.sol";
+import {IERC173} from "@diamond/interfaces/IERC173.sol";
+import {IERC165} from "@diamond/interfaces/IERC165.sol";
 
 // EIP-2535 specifies that the `diamondCut` function takes two optional
 // arguments: address _init and bytes calldata _calldata
@@ -71,6 +71,8 @@ contract GovernorDiamondInit {
         config.quorumNumerator = quorumPercentage;
         config.proposalThreshold = threshold;
         config.proposalThresholdToken = proposalThresholdToken;
+        // by default, we only allow the default proposal token to be used for proposals
+        config.proposalTokens[proposalToken] = true;
 
         // in order to facilitate role administration, we add the admin to the admin role
         // it is advised that the admin renounces this role after the diamond is deployed

--- a/src/utils/GovernorStorage.sol
+++ b/src/utils/GovernorStorage.sol
@@ -20,6 +20,13 @@ library GovernorStorage {
     event DefaultProposalTokenSet(address oldDefaultProposalToken, address newDefaultProposalToken);
 
     /**
+     * @dev Emitted when the proposal token is enabled or disabled.
+     * @param proposalToken The proposal token's address.
+     * @param enabled Whether the proposal token is enabled.
+     */
+    event ProposalTokenEnabled(address proposalToken, bool enabled);
+
+    /**
      * @dev Emitted when the voting delay is set.
      * @param oldVotingDelay The previous voting delay.
      * @param newVotingDelay The new voting delay.
@@ -92,6 +99,7 @@ library GovernorStorage {
         uint64 votingPeriod;
         uint128 quorumNumerator;
         uint256 proposalThreshold;
+        mapping(address => bool) proposalTokens;
     }
 
     struct TimelockQueue {
@@ -137,6 +145,15 @@ library GovernorStorage {
     }
 
     /**
+     * @notice determine if a token is enabled for proposal creation.
+     * @param token the token address to check.
+     * @return true if the token is enabled for proposal creation.
+     */
+     function isProposalTokenEnabled(address token) internal view returns (bool) {
+        return configStorage().proposalTokens[token];
+     }
+
+    /**
      * @notice sets the default counting strategy.
      * @param newDefaultCountingStrategy the new default counting strategy address.
      * emits DefaultCountingStrategySet event.
@@ -158,6 +175,19 @@ library GovernorStorage {
         configStorage().defaultProposalToken = newDefaultProposalToken;
 
         emit DefaultProposalTokenSet(oldDefaultProposalToken, newDefaultProposalToken);
+    }
+
+    /**
+     * @notice set proposal token validity
+     * @param proposalToken the proposal token address.
+     * @param enabled true if the proposal token is valid.
+     * emits ProposalTokenEnabled event.
+     */
+    function enableProposalToken(address proposalToken, bool enabled) internal {
+        require(isConfiguredToken(proposalToken), "Governor: proposal token must be a configured token");
+        configStorage().proposalTokens[proposalToken] = enabled;
+
+        emit ProposalTokenEnabled(proposalToken, enabled);
     }
 
     /**

--- a/test/OrigamiDiamondTestHelper.sol
+++ b/test/OrigamiDiamondTestHelper.sol
@@ -1,21 +1,26 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "src/OrigamiGovernanceToken.sol";
-import "src/OrigamiMembershipToken.sol";
-import "src/OrigamiTimelockController.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {OrigamiMembershipToken} from "src/OrigamiMembershipToken.sol";
+import {OrigamiTimelockController} from "src/OrigamiTimelockController.sol";
+import {SimpleCounting} from "src/governor/lib/SimpleCounting.sol";
 
-import "src/governor/GovernorCoreFacet.sol";
-import "src/governor/GovernorSettingsFacet.sol";
-import "src/governor/GovernorTimelockControlFacet.sol";
-import "src/utils/GovernorDiamondInit.sol";
-import "src/utils/DiamondDeployHelper.sol";
+import {GovernorCoreFacet} from "src/governor/GovernorCoreFacet.sol";
+import {GovernorSettingsFacet} from "src/governor/GovernorSettingsFacet.sol";
+import {GovernorTimelockControlFacet} from "src/governor/GovernorTimelockControlFacet.sol";
+import {GovernorDiamondInit} from "src/utils/GovernorDiamondInit.sol";
+import {DiamondDeployHelper} from "src/utils/DiamondDeployHelper.sol";
 
-import "@std/Test.sol";
-import "@diamond/Diamond.sol";
+import {Test} from "@std/Test.sol";
+import {Diamond} from "@diamond/Diamond.sol";
+import {DiamondLoupeFacet} from "@diamond/facets/DiamondLoupeFacet.sol";
+import {DiamondCutFacet} from "@diamond/facets/DiamondCutFacet.sol";
+import {IDiamondCut} from "@diamond/interfaces/IDiamondCut.sol";
+import {OwnershipFacet} from "@diamond/facets/OwnershipFacet.sol";
 
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 abstract contract GovDiamondAddressHelper {
     address public deployer = address(0x1);
@@ -182,8 +187,11 @@ contract GovernorDiamondHelper is GovDiamondAddressHelper, Test {
         timelockControlFacet = GovernorTimelockControlFacet(address(origamiGovernorDiamond));
         loupeFacet = DiamondLoupeFacet(address(origamiGovernorDiamond));
 
-        vm.prank(address(timelock));
+        vm.startPrank(address(timelock));
         settingsFacet.setGovernanceToken(address(govToken));
+        settingsFacet.enableProposalToken(address(govToken), true);
+        settingsFacet.enableProposalToken(address(memToken), true);
+        vm.stopPrank();
 
         vm.roll(42);
     }

--- a/test/governor/GovernorSettingsFacet.t.sol
+++ b/test/governor/GovernorSettingsFacet.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "src/interfaces/IGovernor.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
 
 contract SettingsFacetTest is GovernorDiamondHelper {


### PR DESCRIPTION
This sets a mapping of proposal token addresses to a boolean representing whether they're a valid choice for proposal voting token.

The PR is a little noisy since I updated imports to specify which contracts were being imported (and to fix the `no-global-imports` warnings from solhint). The changes are focused around the `updateProposalToken` and `isProposalToken` functions and exercising them under test.