### PR TITLE
QSP: Best Practices - part1

### DIFF
--- a/src/interfaces/IVotes.sol
+++ b/src/interfaces/IVotes.sol
@@ -6,11 +6,11 @@ pragma solidity 0.8.16;
  * @notice Common interface for {ERC20Votes}, {ERC721Votes}, and other {Votes}-enabled contracts.
  */
 interface IVotes {
-    /// @dev Emitted when an account changes their delegate.
+    /// @dev Emitted when an account changes their delegatee.
     event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
 
-    /// @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of votes.
-    event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance);
+    /// @dev Emitted when a token transfer or delegatee change results in changes to a delegatee's number of votes.
+    event DelegateVotesChanged(address indexed delegatee, uint256 previousBalance, uint256 newBalance);
 
     /// @dev Returns the current amount of votes that `account` has.
     function getVotes(address account) external view returns (uint256);
@@ -41,9 +41,9 @@ interface IVotes {
     function getDelegatorNonce(address delegator) external view returns (uint256);
 
     /**
-     * @notice Returns the delegate that `account` has chosen.
-     * @param account The address of the account to get the delegate for.
-     * @return The address of the delegate for `account`.
+     * @notice Returns the delegatee that `account` has chosen.
+     * @param account The address of the account to get the delegatee for.
+     * @return The address of the delegatee for `account`.
      */
     function delegates(address account) external view returns (address);
 

--- a/src/utils/Checkpoints.sol
+++ b/src/utils/Checkpoints.sol
@@ -13,14 +13,14 @@ library Checkpoints {
     bytes32 public constant DELEGATE_STORAGE_POSITION = keccak256("com.origami.ivotes.delegates");
 
     /**
-     * @dev Emitted when an account changes their delegate.
+     * @dev Emitted when an account changes their delegatee.
      */
     event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
 
     /**
-     * @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of votes.
+     * @dev Emitted when a token transfer or delegatee change results in changes to a delegatee's number of votes.
      */
-    event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance);
+    event DelegateVotesChanged(address indexed delegatee, uint256 previousBalance, uint256 newBalance);
 
     /// @dev struct to store checkpoint data
     struct Checkpoint {
@@ -196,7 +196,7 @@ library Checkpoints {
 
     /**
      * @notice Returns the address of the account which `account` has delegated to
-     * @param account The address to return the delegate for
+     * @param account The address to return the delegatee for
      * @return The address of the account which `account` delegated to. If `account` has not delegated, returns address(0).
      */
     function delegates(address account) internal view returns (address) {
@@ -233,21 +233,21 @@ library Checkpoints {
     /**
      * @notice Moves the delegated voting weight from one delegatee to another
      * @dev because it calls writeCheckpoint, as a side effect, a DelegateVotesChanged event is emitted
-     * @param oldDelegate The address of the delegate to remove voting units from. If not address(0), then the voting units are removed from the oldDelegate
-     * @param newDelegate The address of the delegate to add voting units to. If not address(0), then the voting units are added to the newDelegate
+     * @param oldDelegate The address of the delegatee to remove voting units from. If not address(0), then the voting units are removed from the oldDelegate
+     * @param newDelegate The address of the delegatee to add voting units to. If not address(0), then the voting units are added to the newDelegate
      * @param amount The number of voting units to move
      */
     function moveDelegation(address oldDelegate, address newDelegate, uint256 amount) internal {
         if (oldDelegate != newDelegate && amount > 0) {
             if (oldDelegate != address(0)) {
-                // decrease old delegate
+                // decrease old delegatee
                 uint256 oldVotes = getVotes(oldDelegate);
                 uint256 newVotes = oldVotes - amount;
                 writeCheckpoint(oldDelegate, oldVotes, newVotes);
             }
 
             if (newDelegate != address(0)) {
-                // increase new delegate
+                // increase new delegatee
                 uint256 oldVotes = getVotes(newDelegate);
                 uint256 newVotes = oldVotes + amount;
                 writeCheckpoint(newDelegate, oldVotes, newVotes);

--- a/src/utils/TransferLocks.sol
+++ b/src/utils/TransferLocks.sol
@@ -42,9 +42,8 @@ contract TransferLocks is ERC20Base, IERC165, ITransferLocks {
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         uint256 lockedAmount = getTransferLockTotal(from);
         // slither-disable-next-line timestamp
-        if (lockedAmount > 0) {
+        if (lockedAmount > 0 && balanceOf(from) >= amount) {
             // slither-disable-next-line timestamp
-            // the require accounts for balanceOf(from) needing to be >= amount
             require(balanceOf(from) - amount >= lockedAmount, "TransferLock: this exceeds your unlocked balance");
         }
         super._beforeTokenTransfer(from, to, amount);

--- a/src/utils/TransferLocks.sol
+++ b/src/utils/TransferLocks.sol
@@ -40,7 +40,7 @@ contract TransferLocks is ERC20Base, IERC165, ITransferLocks {
 
     /// @dev Override ERC20Upgradeable._beforeTokenTransfer to check for transfer locks.
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
-        uint256 lockedAmount = getTransferLockTotalAt(from, block.timestamp);
+        uint256 lockedAmount = getTransferLockTotal(from);
         // slither-disable-next-line timestamp
         if (lockedAmount > 0) {
             // slither-disable-next-line timestamp

--- a/src/utils/TransferLocks.sol
+++ b/src/utils/TransferLocks.sol
@@ -42,8 +42,9 @@ contract TransferLocks is ERC20Base, IERC165, ITransferLocks {
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         uint256 lockedAmount = getTransferLockTotalAt(from, block.timestamp);
         // slither-disable-next-line timestamp
-        if (lockedAmount > 0 && balanceOf(from) >= amount) {
+        if (lockedAmount > 0) {
             // slither-disable-next-line timestamp
+            // the require accounts for balanceOf(from) needing to be >= amount
             require(balanceOf(from) - amount >= lockedAmount, "TransferLock: this exceeds your unlocked balance");
         }
         super._beforeTokenTransfer(from, to, amount);

--- a/test/utils/TransferLocks.t.sol
+++ b/test/utils/TransferLocks.t.sol
@@ -186,7 +186,7 @@ contract TransferLockUseCaseTests is TransferLocksTestHelper {
         vm.expectRevert(); //Reverts with Arithmetic over/underflow
         token.transfer(minter, 200);
     }
-q
+
     function testCannotCreateTransferLockInPast() public {
         vm.warp(10000);
         vm.prank(mintee);

--- a/test/utils/TransferLocks.t.sol
+++ b/test/utils/TransferLocks.t.sol
@@ -182,14 +182,11 @@ contract TransferLockUseCaseTests is TransferLocksTestHelper {
     function testCannotUnderflowAmount() public {
         vm.prank(mintee);
         token.addTransferLock(100, 1000);
-        // we would get an underflow revert if we weren't checking the balance
-        // exceeds the amount, since we do, we get the built-in revert about the
-        // amount being too high
         vm.prank(mintee);
-        vm.expectRevert("ERC20: transfer amount exceeds balance");
+        vm.expectRevert(); //Reverts with Arithmetic over/underflow
         token.transfer(minter, 200);
     }
-
+q
     function testCannotCreateTransferLockInPast() public {
         vm.warp(10000);
         vm.prank(mintee);

--- a/test/utils/TransferLocks.t.sol
+++ b/test/utils/TransferLocks.t.sol
@@ -182,8 +182,11 @@ contract TransferLockUseCaseTests is TransferLocksTestHelper {
     function testCannotUnderflowAmount() public {
         vm.prank(mintee);
         token.addTransferLock(100, 1000);
+        // we would get an underflow revert if we weren't checking the balance
+        // exceeds the amount, since we do, we get the built-in revert about the
+        // amount being too high
         vm.prank(mintee);
-        vm.expectRevert(); //Reverts with Arithmetic over/underflow
+        vm.expectRevert("ERC20: transfer amount exceeds balance");
         token.transfer(minter, 200);
     }
 


### PR DESCRIPTION
There are about 12 total issues listed in their best practices area. This addresses number 4, 6, and 12. There will be additional PR's for others but I didn't want to have them all in one commit just for ease of tracking and reviewing. 

- [ENG-1169: QSP Best Practices #12 ](https://linear.app/joinorigami/issue/ENG-1169/tech-debtcode-cleanup-unnecessary-function-call) <--- Reverted to keep our original messaging
- [ENG-1165: QSP Best Practices #6 ](https://linear.app/joinorigami/issue/ENG-1165/tech-debtcode-cleanup-consistent-use-of-delegatee-or-delegate)
- [ENG-1163: QSP Best Practices #4](https://linear.app/joinorigami/issue/ENG-1163/code-question-use-of-gettransferlocktotal-vs-gettransferlocktotalat) 