### PR TITLE
Make all imports explicit

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "@std/Script.sol";
-import "src/OrigamiGovernanceToken.sol";
-import "src/OrigamiMembershipToken.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Script, console2} from "@std/Script.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {OrigamiMembershipToken} from "src/OrigamiMembershipToken.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
 
 contract DeployScript is Script {
     /**
@@ -80,6 +80,7 @@ contract DeployScript is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         ProxyAdmin admin = new ProxyAdmin();
+        // solhint-disable-next-line no-console
         console2.log("ProxyAdmin deployed at", address(admin));
 
         vm.stopBroadcast();
@@ -93,6 +94,7 @@ contract DeployScript is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         OrigamiGovernanceToken token = new OrigamiGovernanceToken();
+        // solhint-disable-next-line no-console
         console2.log("OrigamiGovernanceToken deployed at", address(token));
 
         vm.stopBroadcast();
@@ -106,6 +108,7 @@ contract DeployScript is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         OrigamiMembershipToken token = new OrigamiMembershipToken();
+        // solhint-disable-next-line no-console
         console2.log("OrigamiMembershipToken deployed at", address(token));
 
         vm.stopBroadcast();

--- a/script/DeterministicDeploy.s.sol
+++ b/script/DeterministicDeploy.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "src/OrigamiGovernanceToken.sol";
-import "src/OrigamiMembershipToken.sol";
-import "src/token/governance/ERC20Base.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {OrigamiMembershipToken} from "src/OrigamiMembershipToken.sol";
+import {ERC20Base} from "src/token/governance/ERC20Base.sol";
 
-import "@std/Script.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@create3/CREATE3Factory.sol";
+import {Script, console2} from "@std/Script.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {CREATE3Factory} from "@create3/CREATE3Factory.sol";
 
 contract DeterministicDeployHelper is Script {
     function transparentProxyByteCode(address implementation, address proxyAdmin) public pure returns (bytes memory) {
@@ -39,6 +39,7 @@ contract DeterministicDeploy is DeterministicDeployHelper {
     function deployCreate3Factory() public {
         vm.startBroadcast();
         CREATE3Factory c3 = new CREATE3Factory();
+        // solhint-disable-next-line no-console
         console2.log("CREATE3Factory deployed at", address(c3));
         vm.stopBroadcast();
     }
@@ -50,6 +51,7 @@ contract DeterministicDeploy is DeterministicDeployHelper {
 
         vm.startBroadcast();
         address erc20Base = c3.deploy(bytes32(bytes(salt)), bytecode);
+        // solhint-disable-next-line no-console
         console2.log("ERC20Base deployed at", erc20Base);
         vm.stopBroadcast();
     }
@@ -61,6 +63,7 @@ contract DeterministicDeploy is DeterministicDeployHelper {
 
         vm.startBroadcast();
         address govToken = c3.deploy(bytes32(bytes(salt)), bytecode);
+        // solhint-disable-next-line no-console
         console2.log("OrigamiGovernanceToken deployed at", govToken);
         vm.stopBroadcast();
     }

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "@std/Script.sol";
-import "src/OrigamiGovernanceToken.sol";
-import "src/OrigamiMembershipToken.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Script} from "@std/Script.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {OrigamiMembershipToken} from "src/OrigamiMembershipToken.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
 
 contract UpgradeScript is Script {
     /**

--- a/script/Util.s.sol
+++ b/script/Util.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.16;
 
-import "src/interfaces/IAccessControl.sol";
-import "src/OrigamiGovernanceToken.sol";
-import "src/utils/L2StandardERC20.sol";
+import {IAccessControl} from "src/interfaces/IAccessControl.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {L2StandardERC20} from "src/utils/L2StandardERC20.sol";
 
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@std/Script.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Script} from "@std/Script.sol";
 
 contract GrantPermissions is Script {
     bytes32 internal constant REVOKER_ROLE = 0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;

--- a/src/OrigamiGovernanceToken.sol
+++ b/src/OrigamiGovernanceToken.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/utils/TransferLocks.sol";
-import "src/utils/Votes.sol";
-import "src/token/governance/ERC20Base.sol";
+import {IVotes} from "src/interfaces/IVotes.sol";
+import {IVotesToken} from "src/interfaces/IVotesToken.sol";
+import {TransferLocks} from "src/utils/TransferLocks.sol";
+import {Votes} from "src/utils/Votes.sol";
+import {ERC20Base} from "src/token/governance/ERC20Base.sol";
+import {ERC20Upgradeable} from "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
 /**
  * @title Origami Governance Token

--- a/src/OrigamiMembershipToken.sol
+++ b/src/OrigamiMembershipToken.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/utils/Votes.sol";
+import {IVotesToken} from "src/interfaces/IVotesToken.sol";
+import {IVotes} from "src/interfaces/IVotes.sol";
+import {Votes} from "src/utils/Votes.sol";
 
-import "@oz-upgradeable/access/AccessControlUpgradeable.sol";
-import "@oz-upgradeable/proxy/utils/Initializable.sol";
-import "@oz-upgradeable/security/PausableUpgradeable.sol";
-import "@oz-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import "@oz-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
-import "@oz-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import "@oz-upgradeable/utils/CountersUpgradeable.sol";
+import {AccessControlUpgradeable} from "@oz-upgradeable/access/AccessControlUpgradeable.sol";
+import {Initializable} from "@oz-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@oz-upgradeable/security/PausableUpgradeable.sol";
+import {IERC721Upgradeable, ERC721Upgradeable} from "@oz-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import {ERC721BurnableUpgradeable} from "@oz-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
+import {ERC721EnumerableUpgradeable} from "@oz-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {CountersUpgradeable} from "@oz-upgradeable/utils/CountersUpgradeable.sol";
 
 /// @title Origami Membership Token
 /// @author Stephen Caudill

--- a/src/OrigamiTimelockController.sol
+++ b/src/OrigamiTimelockController.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/utils/IERC721Receiver.sol";
-import "src/interfaces/utils/IERC1155Receiver.sol";
-import "src/interfaces/ITimelockController.sol";
-import "src/utils/AccessControl.sol";
+import {IERC721Receiver} from "src/interfaces/utils/IERC721Receiver.sol";
+import {IERC1155Receiver} from "src/interfaces/utils/IERC1155Receiver.sol";
+import {ITimelockController} from "src/interfaces/ITimelockController.sol";
+import {AccessControl} from "src/utils/AccessControl.sol";
 
-import "@diamond/interfaces/IERC165.sol";
+import {IERC165} from "@diamond/interfaces/IERC165.sol";
 
 /**
  * @dev Contract module which acts as a timelocked controller. When set as the

--- a/src/governor/GovernorTimelockControlFacet.sol
+++ b/src/governor/GovernorTimelockControlFacet.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/governor/lib/GovernorCommon.sol";
-import "src/interfaces/IGovernor.sol";
-import "src/interfaces/IGovernorTimelockControl.sol";
-import "src/interfaces/ITimelockController.sol";
-import "src/utils/AccessControl.sol";
-import "src/utils/GovernorStorage.sol";
+import {GovernorCommon} from "src/governor/lib/GovernorCommon.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
+import {IGovernorTimelockControl} from "src/interfaces/IGovernorTimelockControl.sol";
+import {ITimelockController} from "src/interfaces/ITimelockController.sol";
+import {AccessControl} from "src/utils/AccessControl.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @title Origami Governor Timelock Control Facet

--- a/src/governor/lib/GovernorCommon.sol
+++ b/src/governor/lib/GovernorCommon.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/governor/lib/SimpleCounting.sol";
-import "src/interfaces/IGovernor.sol";
-import "src/utils/GovernorStorage.sol";
+import {SimpleCounting} from "src/governor/lib/SimpleCounting.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @author Origami

--- a/src/governor/lib/GovernorQuorum.sol
+++ b/src/governor/lib/GovernorQuorum.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/IVotes.sol";
-import "src/utils/GovernorStorage.sol";
+import {IVotes} from "src/interfaces/IVotes.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @title Origami Governor Quorum shared functions

--- a/src/governor/lib/SimpleCounting.sol
+++ b/src/governor/lib/SimpleCounting.sol
@@ -1,10 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/governor/lib/GovernorQuorum.sol";
-import "src/governor/lib/TokenWeightStrategy.sol";
-import "src/governor/lib/Voting.sol";
-import "src/utils/GovernorStorage.sol";
+import {GovernorQuorum} from "src/governor/lib/GovernorQuorum.sol";
+import {TokenWeightStrategy} from "src/governor/lib/TokenWeightStrategy.sol";
+import {Voting} from "src/governor/lib/Voting.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @title Simple Counting strategy

--- a/src/governor/lib/Voting.sol
+++ b/src/governor/lib/Voting.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/utils/GovernorStorage.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 /**
  * @title Core voting interface

--- a/src/interfaces/IGovernorTimelockControl.sol
+++ b/src/interfaces/IGovernorTimelockControl.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/ITimelockController.sol";
+import {ITimelockController} from "src/interfaces/ITimelockController.sol";
 
 interface IGovernorTimelockControl {
     event TimelockChange(address oldTimelock, address newTimelock);

--- a/src/interfaces/utils/IL2StandardERC20.sol
+++ b/src/interfaces/utils/IL2StandardERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "@diamond/interfaces/IERC165.sol";
+import {IERC165} from "@diamond/interfaces/IERC165.sol";
 
 interface ILegacyMintableERC20 is IERC165 {
     /**

--- a/src/token/governance/ERC20Base.sol
+++ b/src/token/governance/ERC20Base.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "@oz-upgradeable/access/AccessControlUpgradeable.sol";
-import "@oz-upgradeable/proxy/utils/Initializable.sol";
-import "@oz-upgradeable/security/PausableUpgradeable.sol";
-import "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import "@oz-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
-import "@oz-upgradeable/token/ERC20/extensions/ERC20CappedUpgradeable.sol";
+import {AccessControlUpgradeable} from "@oz-upgradeable/access/AccessControlUpgradeable.sol";
+import {Initializable} from "@oz-upgradeable/proxy/utils/Initializable.sol";
+import {PausableUpgradeable} from "@oz-upgradeable/security/PausableUpgradeable.sol";
+import {ERC20Upgradeable} from "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {ERC20BurnableUpgradeable} from "@oz-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import {ERC20CappedUpgradeable} from "@oz-upgradeable/token/ERC20/extensions/ERC20CappedUpgradeable.sol";
 
 /**
  * @title Base ERC20 token contract for Origami Governance Tokens

--- a/src/utils/AccessControl.sol
+++ b/src/utils/AccessControl.sol
@@ -3,10 +3,10 @@
 
 pragma solidity 0.8.16;
 
-import "src/interfaces/IAccessControl.sol";
-import "src/utils/AccessControlStorage.sol";
+import {IAccessControl} from "src/interfaces/IAccessControl.sol";
+import {AccessControlStorage} from "src/utils/AccessControlStorage.sol";
 
-import "@oz/utils/Strings.sol";
+import {Strings} from "@oz/utils/Strings.sol";
 
 /**
  * @dev Contract module that allows children to implement role-based access

--- a/src/utils/L2StandardERC20.sol
+++ b/src/utils/L2StandardERC20.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "src/interfaces/utils/IL2StandardERC20.sol";
-import "src/token/governance/ERC20Base.sol";
-import "@diamond/interfaces/IERC165.sol";
-import "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {IL2StandardERC20, ILegacyMintableERC20} from "src/interfaces/utils/IL2StandardERC20.sol";
+import {ERC20Base} from "src/token/governance/ERC20Base.sol";
+import {IERC165} from "@diamond/interfaces/IERC165.sol";
+import {ERC20Upgradeable} from "@oz-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 
 /**
  * @title L2StandardERC20

--- a/test/OrigamiGovernanceToken.t.sol
+++ b/test/OrigamiGovernanceToken.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "@std/Test.sol";
-import "src/OrigamiGovernanceToken.sol";
-import "test/versions/OrigamiGovernanceTokenTestVersion.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@oz/utils/Strings.sol";
+import {Test} from "@std/Test.sol";
+import {OrigamiGovernanceToken} from "src/OrigamiGovernanceToken.sol";
+import {OrigamiGovernanceTokenTestVersion} from "test/versions/OrigamiGovernanceTokenTestVersion.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Strings} from "@oz/utils/Strings.sol";
 
 abstract contract OGTAddressHelper {
     address public deployer = address(0x6);

--- a/test/OrigamiMembershipToken.t.sol
+++ b/test/OrigamiMembershipToken.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "@std/Test.sol";
-import "src/OrigamiMembershipToken.sol";
-import "test/versions/OrigamiMembershipTokenTestVersion.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@oz/utils/Strings.sol";
+import {Test} from "@std/Test.sol";
+import {OrigamiMembershipToken} from "src/OrigamiMembershipToken.sol";
+import {OrigamiMembershipTokenTestVersion} from "test/versions/OrigamiMembershipTokenTestVersion.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Strings} from "@oz/utils/Strings.sol";
 
 abstract contract OMTAddressHelper {
     address public owner = address(0x1);

--- a/test/OrigamiTimelockController.t.sol
+++ b/test/OrigamiTimelockController.t.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "src/OrigamiTimelockController.sol";
-import "src/interfaces/utils/IERC721Receiver.sol";
-import "src/interfaces/utils/IERC1155Receiver.sol";
-import "src/interfaces/ITimelockController.sol";
+import {OrigamiTimelockController} from "src/OrigamiTimelockController.sol";
+import {IERC721Receiver} from "src/interfaces/utils/IERC721Receiver.sol";
+import {IERC1155Receiver} from "src/interfaces/utils/IERC1155Receiver.sol";
+import {ITimelockController} from "src/interfaces/ITimelockController.sol";
+import {IERC165} from "@oz/utils/introspection/IERC165.sol";
 
-import "@std/Test.sol";
+import {Test} from "@std/Test.sol";
 
 contract OrigamiTimelockControllerTest is Test {
     address public deployer = address(0xbeefea7e2);

--- a/test/governor/GovernorCoreFacet.t.sol
+++ b/test/governor/GovernorCoreFacet.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.16;
 
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
 
-import "src/interfaces/IAccessControl.sol";
-import "src/interfaces/IGovernor.sol";
-import "src/interfaces/IGovernorQuorum.sol";
-import "src/interfaces/IGovernorSettings.sol";
-import "src/interfaces/IGovernorTimelockControl.sol";
-import "@diamond/interfaces/IERC165.sol";
+import {IAccessControl} from "src/interfaces/IAccessControl.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
+import {IGovernorQuorum} from "src/interfaces/IGovernorQuorum.sol";
+import {IGovernorSettings} from "src/interfaces/IGovernorSettings.sol";
+import {IGovernorTimelockControl} from "src/interfaces/IGovernorTimelockControl.sol";
+import {IERC165} from "@diamond/interfaces/IERC165.sol";
 
 contract OrigamiGovernorCoreTest is GovernorDiamondHelper {
     address[] public targets;

--- a/test/governor/lib/GovernorCommon.t.sol
+++ b/test/governor/lib/GovernorCommon.t.sol
@@ -2,8 +2,12 @@
 pragma solidity 0.8.16;
 
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
+import {TokenWeightStrategy} from "src/governor/lib/TokenWeightStrategy.sol";
 
-import "src/governor/lib/GovernorCommon.sol";
+import {IGovernor} from "src/interfaces/IGovernor.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
+import {GovernorCommon} from "src/governor/lib/GovernorCommon.sol";
+import {SimpleCounting} from "src/governor/lib/SimpleCounting.sol";
 
 contract CommonContract is GovernorDiamondHelper {
     constructor() {

--- a/test/governor/lib/GovernorQuorum.t.sol
+++ b/test/governor/lib/GovernorQuorum.t.sol
@@ -3,8 +3,10 @@ pragma solidity 0.8.16;
 
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
 
-import "src/governor/lib/GovernorQuorum.sol";
-import "src/governor/lib/TokenWeightStrategy.sol";
+import {GovernorQuorum} from "src/governor/lib/GovernorQuorum.sol";
+import {TokenWeightStrategy} from "src/governor/lib/TokenWeightStrategy.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
+
 
 contract QuorumContract {
     address public governanceToken;

--- a/test/governor/lib/SimpleCounting.t.sol
+++ b/test/governor/lib/SimpleCounting.t.sol
@@ -3,8 +3,9 @@ pragma solidity 0.8.16;
 
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
 
-import "src/governor/lib/SimpleCounting.sol";
-import "src/governor/lib/TokenWeightStrategy.sol";
+import {SimpleCounting} from "src/governor/lib/SimpleCounting.sol";
+import {TokenWeightStrategy} from "src/governor/lib/TokenWeightStrategy.sol";
+import {GovernorStorage} from "src/utils/GovernorStorage.sol";
 
 contract SimpleContract {
     constructor() {

--- a/test/governor/lib/TokenWeightStrategy.t.sol
+++ b/test/governor/lib/TokenWeightStrategy.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.16;
 
 import {GovernorDiamondHelper} from "test/OrigamiDiamondTestHelper.sol";
 
-import "src/governor/lib/TokenWeightStrategy.sol";
-import "@std/Test.sol";
+import {TokenWeightStrategy} from "src/governor/lib/TokenWeightStrategy.sol";
+import {Test} from "@std/Test.sol";
 
 contract TokenWeightStrategyTest is Test {
     bytes4 internal constant simpleWeightSelector = bytes4(keccak256("simpleWeight(uint256)"));

--- a/test/token/governance/ERC20Base.t.sol
+++ b/test/token/governance/ERC20Base.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "@std/Test.sol";
-import "src/token/governance/ERC20Base.sol";
-import "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@oz/utils/Strings.sol";
+import {Test} from "@std/Test.sol";
+import {ERC20Base} from "src/token/governance/ERC20Base.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Strings} from "@oz/utils/Strings.sol";
 
 abstract contract ERC20AddressHelper {
     address public deployer = address(0x6);

--- a/test/utils/AccessControl.t.sol
+++ b/test/utils/AccessControl.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "src/utils/AccessControl.sol";
+import {AccessControl} from "src/utils/AccessControl.sol";
 
-import "@std/Test.sol";
-import "@oz/utils/Strings.sol";
+import {Test} from "@std/Test.sol";
+import {Strings} from "@oz/utils/Strings.sol";
 
 abstract contract AccessControlHelper {
     address public deployer = address(0x1);

--- a/test/utils/L2StandardERC20.t.sol
+++ b/test/utils/L2StandardERC20.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: ITSATEST
 pragma solidity 0.8.16;
 
-import "src/utils/L2StandardERC20.sol";
+import {L2StandardERC20} from "src/utils/L2StandardERC20.sol";
+import {IL2StandardERC20, ILegacyMintableERC20} from "src/interfaces/utils/IL2StandardERC20.sol";
 
-import "src/interfaces/utils/IL2StandardERC20.sol";
-import "@oz/proxy/transparent/ProxyAdmin.sol";
-import "@std/Test.sol";
+import {IERC165} from "@oz/utils/introspection/IERC165.sol";
+import {ProxyAdmin} from "@oz/proxy/transparent/ProxyAdmin.sol";
+import {Test} from "@std/Test.sol";
+import {TransparentUpgradeableProxy} from "@oz/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 abstract contract L2StandardERC20Helper {
     address public deployer = address(0x1);


### PR DESCRIPTION
This resolves solhint's no-global-import warnings throughout the codebase.