### PR TITLE
Update jib to use v1.* version of argc

### DIFF
--- a/bin/jib
+++ b/bin/jib
@@ -495,4 +495,4 @@ deployLocal() {
     --private-key $argc_private_key
 }
 
-eval $(argc "$0" "$@")
+eval "$(argc --argc-eval "$0" "$@")"


### PR DESCRIPTION
 - This will require an update of argc as it is a breaking change. Just run `cargo install argc` again to get latest version