### PR TITLE
Move to using private key as option and msg.sender in cg

### DIFF
--- a/bin/jib
+++ b/bin/jib
@@ -357,11 +357,13 @@ deployGovernorTimelockController() {
 # @option -p --private-key! (this needs to be the admin's private key not the deployer's)
 # @option -f --rpc-url=http://localhost:8545 The url of the RPC endpoint.
 configureGovernor() {
-  PRIVATE_KEY=$argc_private_key forge script \
-    script/Governor.s.sol:GovernorInstance \
+  declare -a options=()
+  options=$(createOptions $argc_rpc_url 1000000)
+  forge script script/Governor.s.sol:GovernorInstance \
     $argc_init $argc_diamond $argc_timelock $argc_path \
-    --sig "configure(address,address,address,string)" \
-    --rpc-url $argc_rpc_url --broadcast
+    --private-key $argc_private_key \
+    ${options[@]} \
+    --sig "configure(address,address,address,string)"
 }
 
 # @cmd deploy a create3 factory contract

--- a/configs/local-config.json
+++ b/configs/local-config.json
@@ -12,7 +12,7 @@
   "k_proposalThreshold": "100000000000000000000",
   "l_votingPeriod": 300,
   "m_votingDelay": 300,
-  "n_quorumNumerator": 10,
+  "n_quorumNumerator": 1,
   "o_quorumDenominator": 100,
   "p_enableGovernaceToken": true,
   "q_enableMembershipToken": true

--- a/script/Governor.s.sol
+++ b/script/Governor.s.sol
@@ -175,14 +175,13 @@ contract GovernorInstance is Script {
         address timelock,
         string calldata relativeConfigPath
     ) external {
-        uint256 adminPrivateKey = vm.envUint("PRIVATE_KEY");
-        address admin = vm.addr(adminPrivateKey);
-
         GovernorConfig memory config = parseGovernorConfig(relativeConfigPath);
 
-        vm.startBroadcast(adminPrivateKey);
+        vm.startBroadcast();
         IDiamondCut.FacetCut[] memory cuts = facetCuts(config);
-        DiamondCutFacet(governorDiamond).diamondCut(cuts, governorDiamondInit, encodeConfig(admin, timelock, config));
+        DiamondCutFacet(governorDiamond).diamondCut(
+            cuts, governorDiamondInit, encodeConfig(msg.sender, timelock, config)
+        );
         vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
 - Foundry upgrade started to fail on cg call for local host so moving to use the standard options and sending the PK as an option fixes it. We also needed to move to using msg.sender in the encodeConfig method.